### PR TITLE
updating master template links

### DIFF
--- a/include/template.inc
+++ b/include/template.inc
@@ -2,8 +2,11 @@
 <?php include "$root/include/globals.inc" ?>
 <head>
 <TITLE>The Mercury Project: <?php echo $title?></TITLE>
+<link rel="alternate" type="application/rss+xml" title="Mercury News Feed" href="<?php echo $root?>/rss.xml"/>
 <link rel="stylesheet" type="text/css" href="<?php echo $root?>/css/common.css"/>
-<link rel="icon" type="image/ico" href="../favicon.ico"/>
+<link rel="icon" href="<?php echo $root?>/images/mercurylogo_110x110.png"/>
+<link rel="icon" type="image/x-icon" href="<?php echo $root?>/favicon.ico"/>
+<link rel="icon" type="image/png" href="<?php echo $root?>/images/mercurylogo_110x110.png"/>
 </head>
 <body>
 


### PR DESCRIPTION
From https://en.wikipedia.org/wiki/Favicon, determined the best order for all major browsers to link
the favicon both in .ico and .png format (image/png uses compression and supports alpha transparency).

include/template.inc:
  * Adding the RSS feed as a link for easy feed discovery
  * Using the $root variable instead of ".." for icon href
  * Firefox+Safari will pick the last icon, IE the first, hence doubled
  * type="image/x-icon" works for IE (and all other Browsers)