### PR TITLE
Fix mailing list archive search

### DIFF
--- a/mailing-lists/include/mailing-lists.inc
+++ b/mailing-lists/include/mailing-lists.inc
@@ -13,14 +13,14 @@ of the Mercury implementation, tools for Mercury programmers
 <li>
 The <code>users</code> list is intended for general discussion
 about Mercury and related matters of interest to Mercury users.<br>
-It is <A HREF="http://lists.mercurylang.org/pipermail/users/">
+It is <A HREF="https://lists.mercurylang.org/archives/users/">
 archived</A> and searchable.
 
 <li>
 The <code>developers</code> list is intended for general discussion
 about the development of Mercury and the Mercury implementation and related
 matters of interest to the developers of Mercury.<br>
-It is <A HREF="http://lists.mercurylang.org/pipermail/developers/">archived</A> and searchable.
+It is <A HREF="https://lists.mercurylang.org/archives/developers/">archived</A> and searchable.
 Note that in recent times, most the actual development discussion seems to be
 done on the <code>reviews</code> list, rather than <code>developers</code> list.
 <br>
@@ -31,7 +31,7 @@ Mercury, for the purpose of reviewing changes to the Mercury implementation
 (including documentation, test suite, etc.) and the Mercury web site.  This
 list is specifically for posting diffs, reviews of diffs, and discussion of
 issues raised in such reviews.  It tends to be a fairly high-volume list.<br>
-It is <A HREF="http://lists.mercurylang.org/pipermail/reviews/">archived</A>
+It is <A HREF="https://lists.mercurylang.org/archives/reviews/">archived</A>
 and searchable.
 </ul>
 

--- a/mailing-lists/include/mailing-lists.inc
+++ b/mailing-lists/include/mailing-lists.inc
@@ -50,7 +50,7 @@ mercury-users:
 <input type="text" name="q" size="31" value="" />
 <input type="submit" value="Google Search" />
 <input type="hidden" name="sitesearch"
-	value="lists.mercurylang.org/pipermail/users"/>
+	value="lists.mercurylang.org/archives/users"/>
 </form>
 
 <li>
@@ -59,7 +59,7 @@ mercury-developers:
 <input type="text" name="q" size="31" value="" />
 <input type="submit" value="Google Search" />
 <input type="hidden" name="sitesearch"
-	value="lists.mercurylang.org/pipermail/developers"/>
+	value="lists.mercurylang.org/archives/developers"/>
 </form>
 
 <li>
@@ -68,7 +68,7 @@ mercury-reviews:
 <input type="text" name="q" size="31" value="" />
 <input type="submit" value="Google Search" />
 <input type="hidden" name="sitesearch"
-	 value="lists.mercurylang.org/pipermail/reviews"/>
+	 value="lists.mercurylang.org/archives/reviews"/>
 </form>
 </ul>
 

--- a/mailing-lists/include/mailing-lists.inc
+++ b/mailing-lists/include/mailing-lists.inc
@@ -45,7 +45,7 @@ and searchable.
 ?>
 <ul>
 <li>
-<form method="get" action="http://www.google.com/search">
+<form method="get" action="https://www.google.com/search">
 mercury-users:
 <input type="text" name="q" size="31" value="" />
 <input type="submit" value="Google Search" />
@@ -54,7 +54,7 @@ mercury-users:
 </form>
 
 <li>
-<form method="get" action="http://www.google.com/search">
+<form method="get" action="https://www.google.com/search">
 mercury-developers:
 <input type="text" name="q" size="31" value="" />
 <input type="submit" value="Google Search" />
@@ -63,7 +63,7 @@ mercury-developers:
 </form>
 
 <li>
-<form method="get" action="http://www.google.com/search">
+<form method="get" action="https://www.google.com/search">
 mercury-reviews:
 <input type="text" name="q" size="31" value="" />
 <input type="submit" value="Google Search" />


### PR DESCRIPTION
Prior to these changes using the mailing list search forms on [the mailing list page](https://mercurylang.org/mailing-lists/mailing-lists.html):

* showed a security warning (in Firefox at least):
  <img width="725" alt="Screenshot from 2021-06-01 09-18-15" src="https://user-images.githubusercontent.com/21787/120248757-d3062400-c2bb-11eb-8ab5-f70906fb038d.png">
* always returned zero search results

In this PR I've updated links/references to the mailing list archives to use `/archives/` instead of `/pipermail/` and use `https`.